### PR TITLE
TSCH rtimers

### DIFF
--- a/core/net/mac/tsch/tsch-slot-operation.c
+++ b/core/net/mac/tsch/tsch-slot-operation.c
@@ -102,7 +102,11 @@
 #if RTIMER_SECOND < (32 * 1024)
 #error "TSCH: RTIMER_SECOND < (32 * 1024)"
 #endif
+#if RTIMER_SECOND >= 200000
 #define RTIMER_GUARD (RTIMER_SECOND / 100000)
+#else
+#define RTIMER_GUARD 2u
+#endif
 
 /* A ringbuf storing outgoing packets after they were dequeued.
  * Will be processed layer by tsch_tx_process_pending */

--- a/cpu/msp430/rtimer-arch.h
+++ b/cpu/msp430/rtimer-arch.h
@@ -50,12 +50,17 @@
 
 /* Do the math in 32bits to save precision.
  * Round to nearest integer rather than truncate. */
-#define US_TO_RTIMERTICKS(US)  (((US)>=0) ? \
-                               ((((int32_t)(US)*32768L)+500000) / 1000000L) : \
-                               ((((int32_t)(US)*32768L)-500000) / 1000000L))
-#define RTIMERTICKS_TO_US(T)   (((T)>=0) ? \
-                               ((((int32_t)(T)*1000000L)+16384) / 32768L) : \
-                               ((((int32_t)(T)*1000000L)-16384) / 32768L))
+#define US_TO_RTIMERTICKS(US)  ((US) >= 0 ?                        \
+                               (((int32_t)(US) * (RTIMER_ARCH_SECOND) + 500000) / 1000000L) :      \
+                               ((int32_t)(US) * (RTIMER_ARCH_SECOND) - 500000) / 1000000L)
+
+#define RTIMERTICKS_TO_US(T)   ((T) >= 0 ?                     \
+                               (((int32_t)(T) * 1000000L + ((RTIMER_ARCH_SECOND) / 2)) / (RTIMER_ARCH_SECOND)) : \
+                               ((int32_t)(T) * 1000000L - ((RTIMER_ARCH_SECOND) / 2)) / (RTIMER_ARCH_SECOND))
+
+/* A 64-bit version because the 32-bit one cannot handle T >= 4295 ticks.
+   Intended only for positive values of T. */
+#define RTIMERTICKS_TO_US_64(T)  ((uint32_t)(((uint64_t)(T) * 1000000 + ((RTIMER_ARCH_SECOND) / 2)) / (RTIMER_ARCH_SECOND)))
 
 rtimer_clock_t rtimer_arch_now(void);
 

--- a/platform/jn516x/dev/rtimer-arch.h
+++ b/platform/jn516x/dev/rtimer-arch.h
@@ -49,8 +49,9 @@
 #define RTIMER_ARCH_SECOND (F_CPU / 2)
 #endif
 
-#define US_TO_RTIMERTICKS(D) ((int64_t)(D) << 4)
-#define RTIMERTICKS_TO_US(T)   ((int64_t)(T) >> 4)
+#define US_TO_RTIMERTICKS(D)     ((int64_t)(D) << 4)
+#define RTIMERTICKS_TO_US(T)     ((int64_t)(T) >> 4)
+#define RTIMERTICKS_TO_US_64(T)  RTIMERTICKS_TO_US(T)
 
 rtimer_clock_t rtimer_arch_now(void);
 


### PR DESCRIPTION
Two changes:
* make sure RTIMER_GUARD is always greater or equal to 2 ticks 
* improve the US_TO_RTIMERTICKS, RTIMERTICKS_TO_US  macros and add RTIMERTICKS_TO_US_64 macro