### PR TITLE
Adaptive timesync

### DIFF
--- a/core/net/mac/tsch/Makefile.tsch
+++ b/core/net/mac/tsch/Makefile.tsch
@@ -1,1 +1,1 @@
-CONTIKI_SOURCEFILES += tsch.c tsch-slot-operation.c tsch-queue.c tsch-packet.c tsch-schedule.c tsch-log.c tsch-rpl.c
+CONTIKI_SOURCEFILES += tsch.c tsch-slot-operation.c tsch-queue.c tsch-packet.c tsch-schedule.c tsch-log.c tsch-rpl.c tsch-adaptive-timesync.c

--- a/core/net/mac/tsch/tsch-adaptive-timesync.c
+++ b/core/net/mac/tsch/tsch-adaptive-timesync.c
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2015, SICS Swedish ICT.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+/**
+ * \file
+ *         TSCH adaptive time synchronization
+ * \author
+ *         Atis Elsts <atis.elsts@sics.se>
+ *
+ */
+
+#include "tsch-adaptive-timesync.h"
+#include "tsch-log.h"
+#include <stdio.h>
+
+#if TSCH_ADAPTIVE_TIMESYNC
+
+/* Estimated drift of the time-source neighbor. Can be negative.
+ * Units used: ppm multiplied by 256. */
+static int32_t drift_ppm;
+/* Ticks compensated locally since the last timesync time */
+static int32_t compensated_ticks;
+/* Number of already recorded timesync history entries */
+static uint8_t timesync_entry_count;
+
+/* Units in which drift is stored: ppm * 256 */
+#define TSCH_DRIFT_UNIT (1000ul * 1000 * 256)
+
+/*---------------------------------------------------------------------------*/
+/* Add a value to a moving average estimator */
+static int32_t
+timesync_entry_add(int32_t val, uint32_t time_delta)
+{
+#define NUM_TIMESYNC_ENTRIES 8
+  static int32_t buffer[NUM_TIMESYNC_ENTRIES];
+  static uint8_t pos;
+  int i;
+  if(timesync_entry_count == 0) {
+    pos = 0;
+  }
+  buffer[pos] = val;
+  if(timesync_entry_count < NUM_TIMESYNC_ENTRIES) {
+    timesync_entry_count++;
+  }
+  pos = (pos + 1) % NUM_TIMESYNC_ENTRIES;
+
+  val = 0;
+  for(i = 0; i < timesync_entry_count; ++i) {
+    val += buffer[i];
+  }
+  return val / timesync_entry_count;
+}
+/*---------------------------------------------------------------------------*/
+/* Learn the neighbor drift rate at ppm */
+static void
+timesync_learn_drift_ticks(uint32_t time_delta_asn, int32_t drift_ticks)
+{
+  /* should fit in rtimer_clock_t */
+  rtimer_clock_t time_delta_ticks = time_delta_asn * tsch_timing[tsch_ts_timeslot_length];
+  int32_t real_drift_ticks = drift_ticks + compensated_ticks;
+  int32_t last_drift_ppm = (int32_t)((int64_t)real_drift_ticks * TSCH_DRIFT_UNIT / time_delta_ticks);
+
+  drift_ppm = timesync_entry_add(last_drift_ppm, time_delta_ticks);
+}
+/*---------------------------------------------------------------------------*/
+/* Either reset or update the neighbor's drift */
+void
+tsch_timesync_update(struct tsch_neighbor *n, rtimer_clock_t time_delta, rtimer_clock_t drift_correction)
+{
+  /* Account the drift if either this is a new timesource,
+   * or the timedelta is not too small, as smaller timedelta
+   * means proportionally larger measurement error. */
+  if(last_timesource_neighbor != n
+      || time_delta > TSCH_SLOTS_PER_SECOND / 2) {
+    if(last_timesource_neighbor == n) {
+      timesync_learn_drift_ticks(time_delta, drift_correction);
+    } else {
+      last_timesource_neighbor = n;
+      drift_ppm = 0;
+      timesync_entry_count = 0;
+    }
+    compensated_ticks = 0;
+  }
+}
+/*---------------------------------------------------------------------------*/
+/* Error-accumulation free compensation algorithm */
+static rtimer_clock_t
+compensate_internal(uint32_t time_delta_usec, int32_t drift_ppm, int32_t *remainder, int16_t *tick_conversion_error)
+{
+  int64_t d = (int64_t)time_delta_usec * drift_ppm + *remainder;
+  int32_t amount = d / TSCH_DRIFT_UNIT;
+  int32_t amount_ticks;
+
+  *remainder = (int32_t)(d - amount * TSCH_DRIFT_UNIT);
+
+  amount += *tick_conversion_error;
+  amount_ticks = US_TO_RTIMERTICKS(amount);
+  *tick_conversion_error = amount - RTIMERTICKS_TO_US(amount_ticks);
+
+  if(ABS(amount_ticks) > RTIMER_ARCH_SECOND / 128) {
+    TSCH_LOG_ADD(tsch_log_message,
+        snprintf(log->message, sizeof(log->message),
+            "!too big compensation %ld delta %ld", amount_ticks, time_delta_usec));
+    amount_ticks = (amount_ticks > 0 ? RTIMER_ARCH_SECOND : -RTIMER_ARCH_SECOND) / 128;
+  }
+
+  return amount_ticks;
+}
+/*---------------------------------------------------------------------------*/
+/* Do the compensation step before scheduling a new timeslot */
+rtimer_clock_t
+tsch_timesync_adaptive_compensate(rtimer_clock_t time_delta_ticks)
+{
+  static int32_t remainder;
+  static int16_t tick_conversion_error;
+
+  rtimer_clock_t result = 0;
+  uint32_t time_delta_usec = RTIMERTICKS_TO_US_64(time_delta_ticks);
+
+  /* compensate, but not if the neighbor is not known */
+  if(drift_ppm && last_timesource_neighbor != NULL) {
+    result = compensate_internal(time_delta_usec, drift_ppm,
+        &remainder, &tick_conversion_error);
+    compensated_ticks += result;
+  }
+
+  if(TSCH_BASE_DRIFT_PPM) {
+    static int32_t base_drift_remainder;
+    static int16_t base_drift_tick_conversion_error;
+    result += compensate_internal(time_delta_usec, 256ul * TSCH_BASE_DRIFT_PPM,
+        &base_drift_remainder, &base_drift_tick_conversion_error);
+  }
+
+  return result;
+}
+/*---------------------------------------------------------------------------*/
+#else /* TSCH_ADAPTIVE_TIMESYNC */
+/*---------------------------------------------------------------------------*/
+void
+tsch_timesync_update(struct tsch_neighbor *n, rtimer_clock_t delta_ticks, rtimer_clock_t drift_correction)
+{
+}
+/*---------------------------------------------------------------------------*/
+rtimer_clock_t
+tsch_timesync_adaptive_compensate(rtimer_clock_t delta_ticks)
+{
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+#endif /* TSCH_ADAPTIVE_TIMESYNC */

--- a/core/net/mac/tsch/tsch-adaptive-timesync.h
+++ b/core/net/mac/tsch/tsch-adaptive-timesync.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2015, SICS Swedish ICT.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+#ifndef __TSCH_ADAPTIVE_TIMESYNC_H__
+#define __TSCH_ADAPTIVE_TIMESYNC_H__
+
+/********** Includes **********/
+
+#include "contiki.h"
+#include "net/mac/tsch/tsch-private.h"
+
+/******** Configuration *******/
+
+/* Use SFD timestamp for synchronization? By default we merely rely on rtimer and busy wait
+ * until SFD is high, which we found to provide greater accuracy on JN516x and CC2420.
+ * Note: for association, however, we always use SFD timestamp to know the time of arrival
+ * of the EB (because we do not busy-wait for the whole scanning process)
+ * */
+#ifdef TSCH_CONF_RESYNC_WITH_SFD_TIMESTAMPS
+#define TSCH_RESYNC_WITH_SFD_TIMESTAMPS TSCH_CONF_RESYNC_WITH_SFD_TIMESTAMPS
+#else
+#define TSCH_RESYNC_WITH_SFD_TIMESTAMPS 0
+#endif
+
+/* If enabled, remove jitter due to measurement errors */
+#ifdef TSCH_CONF_TIMESYNC_REMOVE_JITTER
+#define TSCH_TIMESYNC_REMOVE_JITTER TSCH_CONF_TIMESYNC_REMOVE_JITTER
+#else
+#define TSCH_TIMESYNC_REMOVE_JITTER TSCH_RESYNC_WITH_SFD_TIMESTAMPS
+#endif
+
+/* The jitter to remove in ticks.
+ * This should be the sum of measurement errors on Tx and Rx nodes.
+ * */
+#define TSCH_TIMESYNC_MEASUREMENT_ERROR US_TO_RTIMERTICKS(32)
+
+/* Base drift value.
+ * Used to compensate locally know inaccuracies, such as
+ * the effect of having a binary 32.768 kHz timer as the TSCH time base. */
+#ifdef TSCH_CONF_BASE_DRIFT_PPM
+#define TSCH_BASE_DRIFT_PPM TSCH_CONF_BASE_DRIFT_PPM
+#else
+#define TSCH_BASE_DRIFT_PPM 0
+#endif
+
+/* The approximate number of slots per second */
+#define TSCH_SLOTS_PER_SECOND (1000000 / TSCH_DEFAULT_TS_TIMESLOT_LENGTH)
+
+/***** External Variables *****/
+
+/* The neighbor last used as our time source */
+extern struct tsch_neighbor *last_timesource_neighbor;
+
+/********** Functions *********/
+
+void tsch_timesync_update(struct tsch_neighbor *n, rtimer_clock_t delta_ticks, rtimer_clock_t drift_correction);
+
+rtimer_clock_t tsch_timesync_adaptive_compensate(rtimer_clock_t delta_ticks);
+
+#endif /* __TSCH_ADAPTIVE_TIMESYNC_H__ */

--- a/core/net/mac/tsch/tsch-conf.h
+++ b/core/net/mac/tsch/tsch-conf.h
@@ -168,4 +168,11 @@
 #define TSCH_WITH_LINK_SELECTOR 0
 #endif /* TSCH_CONF_WITH_LINK_SELECTOR */
 
+/* Estimate the drift of the time-source neighbor and compensate for it? */
+#ifdef TSCH_CONF_ADAPTIVE_TIMESYNC
+#define TSCH_ADAPTIVE_TIMESYNC TSCH_CONF_ADAPTIVE_TIMESYNC
+#else
+#define TSCH_ADAPTIVE_TIMESYNC 0
+#endif
+
 #endif /* __TSCH_CONF_H__ */

--- a/core/net/mac/tsch/tsch-slot-operation.h
+++ b/core/net/mac/tsch/tsch-slot-operation.h
@@ -74,17 +74,6 @@
 #define TSCH_MAX_INCOMING_PACKETS 4
 #endif
 
-/* Use SFD timestamp for synchronization? By default we merely rely on rtimer and busy wait
- * until SFD is high, which we found to provide greater accuracy on JN516x and CC2420.
- * Note: for association, however, we always use SFD timestamp to know the time of arrival
- * of the EB (because we do not busy-wait for the whole scanning process)
- * */
-#ifdef TSCH_CONF_RESYNC_WITH_SFD_TIMESTAMPS
-#define TSCH_RESYNC_WITH_SFD_TIMESTAMPS TSCH_CONF_RESYNC_WITH_SFD_TIMESTAMPS
-#else
-#define TSCH_RESYNC_WITH_SFD_TIMESTAMPS 0
-#endif
-
 /*********** Callbacks *********/
 
 /* Called by TSCH form interrupt after receiving a frame, enabled upper-layer to decide

--- a/cpu/msp430/rtimer-arch.h
+++ b/cpu/msp430/rtimer-arch.h
@@ -62,6 +62,9 @@
    Intended only for positive values of T. */
 #define RTIMERTICKS_TO_US_64(T)  ((uint32_t)(((uint64_t)(T) * 1000000 + ((RTIMER_ARCH_SECOND) / 2)) / (RTIMER_ARCH_SECOND)))
 
+/* ~30.5 microsecond error */
+#define RTIMER_ARCH_MEASUREMENT_ERROR   US_TO_RTIMERTICKS(30)
+
 rtimer_clock_t rtimer_arch_now(void);
 
 #endif /* RTIMER_ARCH_H_ */

--- a/cpu/msp430/rtimer-arch.h
+++ b/cpu/msp430/rtimer-arch.h
@@ -62,9 +62,6 @@
    Intended only for positive values of T. */
 #define RTIMERTICKS_TO_US_64(T)  ((uint32_t)(((uint64_t)(T) * 1000000 + ((RTIMER_ARCH_SECOND) / 2)) / (RTIMER_ARCH_SECOND)))
 
-/* ~30.5 microsecond error */
-#define RTIMER_ARCH_MEASUREMENT_ERROR   US_TO_RTIMERTICKS(30)
-
 rtimer_clock_t rtimer_arch_now(void);
 
 #endif /* RTIMER_ARCH_H_ */

--- a/platform/jn516x/Makefile.jn516x
+++ b/platform/jn516x/Makefile.jn516x
@@ -75,7 +75,8 @@ SIZE:=$(CROSS_COMPILE)-size
 OBJCOPY:=$(CROSS_COMPILE)-objcopy
 OBJDUMP:=$(CROSS_COMPILE)-objdump
 
-ARCH = ccm-star.c exceptions.c rtimer-arch.c slip_uart0.c clock.c micromac-radio.c \
+ARCH = ccm-star.c exceptions.c rtimer-arch.c rtimer-arch-slow.c \
+       slip_uart0.c clock.c micromac-radio.c \
        mtarch.c node-id.c watchdog.c log.c ringbufindex.c slip.c sprintf.c 
 # Default uart0 for printf and slip
 TARGET_WITH_UART0 ?= 1

--- a/platform/jn516x/README.md
+++ b/platform/jn516x/README.md
@@ -47,7 +47,7 @@ The following features have been implemented:
   * Contiki system clock and rtimers (16MHz tick frequency based on 32 MHz crystal)
   * 32.768kHz external oscillator
   * Periodic DCO recalibration
-  * CPU "doze" mode
+  * CPU "doze" and "sleep" modes
   * HW random number generator used as a random seed for pseudo-random generator
   * Watchdog, JN516x HW exception handlers
 
@@ -60,7 +60,6 @@ The following hardware platforms have been tested:
 ## TODO list
 
 The following features are planned:
-  * CPU deeper sleep mode support (where the 32 MHz crystal is turned off)
   * Time-accurate radio primitives ("send at", "listen until")
   * External storage
 
@@ -165,13 +164,13 @@ The following platform-specific configurations are supported:
 
 ### Enabling specific hardware features
 
-The JN516X Contiki platform supports sleep mode (with RAM retention and keeping external oscillator on). To enable sleeping, configure `JN516X_SLEEP_CONF_ENABLED=1`.
+The JN516X Contiki platform supports sleep mode (with RAM retention and keeping the external oscillator on). To enable sleeping, configure `JN516X_SLEEP_CONF_ENABLED=1`.
 
-Sleeping will only happen if there at least 50 ms until the next rtimer or rtimer. Also, the system will wake up ~10 ms before the next timer should fire in order to reininitialize all hardware peripherals.
+Sleeping will only happen if there at least 50 ms until the next rtimer or etimer. Also, the system will wake up ~10 ms before the next timer should fire in order to reininitialize all hardware peripherals.
 
-The JN516X Contiki platform also supports rtimers at two different speeds: 16 MHz and 32 kHz. By default, the high-speed timer is used. The two timers have similar expected accuracy (drift ppm), but 16 MHz has higher precision. However, the low-speed timers are also kept running during sleeping. 
+The JN516X Contiki platform also supports rtimers at two different speeds: 16 MHz and 32 kHz. By default, the high-speed timer is used. The two timers have similar expected accuracy (drift ppm), but the 16 MHz one has higher precision. However, the low-speed timers are also kept running during sleeping. 
 
-To enable low-speed timers, set `RTIMER_USE_32KHZ=1`. An external crystal oscillator is required to achieve reasonable accuracy in this case. Tthis oscilator is present on most platforms and is enabled depending on whether 32kHz timers or sleeping are enabled.
+To enable the low-frequency timer option, set `RTIMER_USE_32KHZ=1`. An external crystal oscillator is required to achieve reasonable accuracy in this case. This oscilator is present on most platforms, and is enabled automatically if either 32kHz timers or sleeping are enabled.
 
 ### Node IEEE/RIME/IPv6 Addresses
 

--- a/platform/jn516x/README.md
+++ b/platform/jn516x/README.md
@@ -163,6 +163,16 @@ The following platform-specific configurations are supported:
 * DR1174 with DR1199 sensor board; enable this with `JN516x_WITH_DR1199 = 1` (will set `JN516x_WITH_DR1174` automatically)
 * USB dongle; enable this with `JN516x_WITH_DONGLE = 1`
 
+### Enabling specific hardware features
+
+The JN516X Contiki platform supports sleep mode (with RAM retention and keeping external oscillator on). To enable sleeping, configure `JN516X_SLEEP_CONF_ENABLED=1`.
+
+Sleeping will only happen if there at least 50 ms until the next rtimer or rtimer. Also, the system will wake up ~10 ms before the next timer should fire in order to reininitialize all hardware peripherals.
+
+The JN516X Contiki platform also supports rtimers at two different speeds: 16 MHz and 32 kHz. By default, the high-speed timer is used. The two timers have similar expected accuracy (drift ppm), but 16 MHz has higher precision. However, the low-speed timers are also kept running during sleeping. 
+
+To enable low-speed timers, set `RTIMER_USE_32KHZ=1`. An external crystal oscillator is required to achieve reasonable accuracy in this case. Tthis oscilator is present on most platforms and is enabled depending on whether 32kHz timers or sleeping are enabled.
+
 ### Node IEEE/RIME/IPv6 Addresses
 
 Nodes will autoconfigure their IPv6 address based on their 64-bit IEEE/MAC address. The 64-bit MAC address is read directly from JN516x System on Chip.

--- a/platform/jn516x/contiki-jn516x-main.c
+++ b/platform/jn516x/contiki-jn516x-main.c
@@ -37,6 +37,7 @@
  *
  * \author
  *         Beshr Al Nahas <beshr@sics.se>
+ *         Atis Elsts <atis.elsts@sics.se>
  */
 
 #include <stdio.h>
@@ -48,6 +49,7 @@
 #include <BbcAndPhyRegs.h>
 #include <recal.h>
 #include "dev/uart0.h"
+#include "dev/uart-driver.h"
 
 #include "contiki.h"
 #include "net/netstack.h"
@@ -112,6 +114,17 @@ static uint8_t is_gateway;
 #ifdef EXPERIMENT_SETUP
 #include "experiment-setup.h"
 #endif
+
+/* _EXTRA_LPM is the sleep mode, _LPM is the doze mode */
+#define ENERGEST_TYPE_EXTRA_LPM ENERGEST_TYPE_LPM
+
+static void main_loop(void);
+
+#if DCOSYNCH_CONF_ENABLED
+static unsigned long last_dco_calibration_time;
+#endif
+static uint64_t sleep_start;
+static uint64_t sleep_start_rtimer;
 
 /*---------------------------------------------------------------------------*/
 #define DEBUG 1
@@ -255,25 +268,17 @@ set_linkaddr(void)
 #endif
 }
 /*---------------------------------------------------------------------------*/
-#if USE_EXTERNAL_OSCILLATOR
-static bool_t
-init_xosc(void)
+bool_t
+xosc_init(void)
 {
   /* The internal 32kHz RC oscillator is used by default;
    * Initialize and enable the external 32.768kHz crystal.
    */
   vAHI_Init32KhzXtal();
-  /* wait for 1.0 seconds for the crystal to stabilize */
-  clock_time_t start = clock_time();
-  clock_time_t now;
-  do {
-    now = clock_time();
-    watchdog_periodic();
-  } while(now - start < CLOCK_SECOND);
-  /* switch to the 32.768 kHz crystal */
+  /* Switch to the 32.768kHz crystal.
+   * This will block and wait up to 1 sec for it to stabilize. */
   return bAHI_Set32KhzClockMode(E_AHI_XTAL);
 }
-#endif
 /*---------------------------------------------------------------------------*/
 #if WITH_TINYOS_AUTO_IDS
 uint16_t TOS_NODE_ID = 0x1234; /* non-zero */
@@ -285,7 +290,23 @@ main(void)
   /* Set stack overflow address for detecting overflow in runtime */
   vAHI_SetStackOverflow(TRUE, ((uint32_t *)&heap_location)[0]);
 
+  /* Initialize random with a seed from the SoC random generator.
+   * This must be done before selecting the high-precision external oscillator.
+   */
+  vAHI_StartRandomNumberGenerator(E_AHI_RND_SINGLE_SHOT, E_AHI_INTS_DISABLED);
+  random_init(u16AHI_ReadRandomNumber());
+
   clock_init();
+  rtimer_init();
+
+#if JN516X_EXTERNAL_CRYSTAL_OSCILLATOR
+  /* initialize the 32kHz crystal and wait for ready */
+  xosc_init();
+  /* need to reinitialize because the wait-for-ready process uses system timers */
+  clock_init();
+  rtimer_init();
+#endif
+
   watchdog_init();
   leds_init();
   leds_on(LEDS_ALL);
@@ -308,19 +329,9 @@ main(void)
   }
 #endif
 
-  /* Initialize random with a seed from the SoC random generator.
-   * This must be done before selecting the high-precision external oscillator.
-   */
-  vAHI_StartRandomNumberGenerator(E_AHI_RND_SINGLE_SHOT, E_AHI_INTS_DISABLED);
-  random_init(u16AHI_ReadRandomNumber());
-
   process_init();
   ctimer_init();
   uart0_init(UART_BAUD_RATE); /* Must come before first PRINTF */
-
-#if USE_EXTERNAL_OSCILLATOR
-  init_xosc();
-#endif
 
 #if NETSTACK_CONF_WITH_IPV4
   slip_arch_init(UART_BAUD_RATE);
@@ -406,6 +417,18 @@ main(void)
   start_autostart_processes();
 
   leds_off(LEDS_ALL);
+
+  /* need this to reliably generate the first rtimer callback */
+  (void)u32AHI_Init();
+
+  main_loop();
+
+  return -1;
+}
+
+static void
+main_loop(void)
+{
   int r;
   while(1) {
     do {
@@ -423,7 +446,6 @@ main(void)
      * if we have more than 500uSec until next rtimer
      * PS: Calibration disables interrupts and blocks for 200uSec.
      *  */
-    static unsigned long last_dco_calibration_time = 0;
     if(clock_seconds() - last_dco_calibration_time > DCOSYNCH_PERIOD) {
       if(rtimer_arch_get_time_until_next_wakeup() > RTIMER_SECOND / 2000) {
         /* PRINTF("ContikiMain: Calibrating the DCO\n"); */
@@ -434,15 +456,64 @@ main(void)
       }
     }
 #endif /* DCOSYNCH_CONF_ENABLED */
-    ENERGEST_OFF(ENERGEST_TYPE_CPU);
-    ENERGEST_ON(ENERGEST_TYPE_LPM);
-    vAHI_CpuDoze();
-    watchdog_start();
-    ENERGEST_OFF(ENERGEST_TYPE_LPM);
-    ENERGEST_ON(ENERGEST_TYPE_CPU);
-  }
 
-  return 0;
+#if JN516X_SLEEP_ENABLED
+    /* flush standard output before sleeping */
+    uart_driver_flush(E_AHI_UART_0);
+
+    /* we can sleep only up to the next rtimer/etimer */
+    rtimer_clock_t max_sleep_time = rtimer_arch_get_time_until_next_wakeup();
+    if(max_sleep_time >= JN516X_MIN_SLEEP_TIME) {
+      /* also take into account etimers */
+      clock_t etimer_expiration = etimer_next_expiration_time();
+      if(etimer_expiration != 0) {
+       clock_t diff = etimer_expiration - clock_time();
+        if((int32_t)diff <= 0) {
+          max_sleep_time = 0;
+        } else {
+          uint64_t until_etimer = (uint64_t)diff * RTIMER_SECOND / CLOCK_SECOND;
+          if(until_etimer < max_sleep_time) {
+            max_sleep_time = until_etimer;
+          }
+        }
+      }
+    }
+
+    if(max_sleep_time >= JN516X_MIN_SLEEP_TIME) {
+      if(max_sleep_time == (rtimer_clock_t)-1) {
+        /* use a default maximal time: 1 second */
+        max_sleep_time = RTIMER_SECOND;
+      } else {
+        max_sleep_time -= JN516X_SLEEP_GUARD_TIME;
+      }
+
+#if !RTIMER_USE_32KHZ
+      /* convert to 32.768 kHz oscillator ticks */
+      max_sleep_time = (uint64_t)max_sleep_time * JN516X_XOSC_SECOND / RTIMER_SECOND;
+#endif
+      vAHI_WakeTimerEnable(WAKEUP_TIMER, TRUE);
+      /* sync with the tick timer */
+      WAIT_FOR_EDGE(sleep_start);
+#if RTIMER_USE_32KHZ
+      sleep_start_rtimer = sleep_start;
+#else
+      sleep_start_rtimer = u32AHI_TickTimerRead();
+#endif
+
+      vAHI_WakeTimerStartLarge(WAKEUP_TIMER, max_sleep_time);
+      ENERGEST_SWITCH(ENERGEST_TYPE_CPU, ENERGEST_TYPE_EXTRA_LPM);
+      vAHI_Sleep(E_AHI_SLEEP_OSCON_RAMON);
+    } else {
+#else
+    {
+#endif /* JN516X_SLEEP_ENABLED */
+      ENERGEST_SWITCH(ENERGEST_TYPE_CPU, ENERGEST_TYPE_LPM);
+      vAHI_CpuDoze();
+      u32AHI_Init();
+      watchdog_start();
+      ENERGEST_SWITCH(ENERGEST_TYPE_LPM, ENERGEST_TYPE_CPU);
+    }
+  }
 }
 /*---------------------------------------------------------------------------*/
 void
@@ -456,7 +527,53 @@ void
 AppWarmStart(void)
 {
   /* Wakeup after sleep with memory on.
-   * TODO: Need to initialize devices but not the application state */
-  main();
+   * Need to initialize devices but not the application state.
+   * Note: the actual time this function is called is
+   * ~8 ticks (32kHz timer) later than the scheduled sleep end time.
+   */
+  uint32_t sleep_ticks;
+  uint64_t sleep_end;
+  rtimer_clock_t sleep_ticks_rtimer;
+
+  clock_calibrate();
+  leds_init();
+  uart0_init(UART_BAUD_RATE); /* Must come before first PRINTF */
+  NETSTACK_RADIO.init();
+  watchdog_init();
+  watchdog_stop();
+
+  WAIT_FOR_EDGE(sleep_end);
+  sleep_ticks = (uint32_t)(sleep_start - sleep_end) + 1;
+
+#if RTIMER_USE_32KHZ
+  sleep_ticks_rtimer = sleep_ticks;
+#else
+  {
+    static uint32_t remainder;
+    uint64_t t = (uint64_t)sleep_ticks * RTIMER_SECOND + remainder;
+    sleep_ticks_rtimer = (uint32_t)(t / JN516X_XOSC_SECOND);
+    remainder = t - sleep_ticks_rtimer * JN516X_XOSC_SECOND;
+  }
+#endif
+
+  /* reinitialize rtimers */
+  rtimer_arch_reinit(sleep_start_rtimer + sleep_ticks_rtimer);
+
+  ENERGEST_SWITCH(ENERGEST_TYPE_EXTRA_LPM, ENERGEST_TYPE_CPU);
+
+  watchdog_start();
+
+  /* some ticks may have passed; record the time again */
+  WAIT_FOR_EDGE(sleep_end);
+  sleep_ticks = (uint32_t)(sleep_start - sleep_end);
+  /* reinitialize clock  */
+  clock_reinit(sleep_ticks);
+
+#if DCOSYNCH_CONF_ENABLED
+  /* The radio is recalibrated on wakeup */
+  last_dco_calibration_time = clock_seconds();
+#endif
+
+  main_loop();
 }
 /*---------------------------------------------------------------------------*/

--- a/platform/jn516x/dev/rtimer-arch-slow.c
+++ b/platform/jn516x/dev/rtimer-arch-slow.c
@@ -32,9 +32,8 @@
 
 /**
  * \file
- *         RTIMER for NXP jn516x
+ *         RTIMER for NXP jn516x: 32 kHz mode
  * \author
- *         Beshr Al Nahas <beshr@sics.se>
  *         Atis Elsts <atis.elsts@sics.se>
  */
 
@@ -47,7 +46,7 @@
 #include "sys/energest.h"
 #include "sys/process.h"
 
-#if !RTIMER_USE_SLOW
+#if RTIMER_USE_SLOW
 
 #define DEBUG 0
 #if DEBUG
@@ -57,57 +56,74 @@
 #define PRINTF(...)
 #endif
 
-#define RTIMER_TIMER_ISR_DEV  E_AHI_DEVICE_TICK_TIMER
+#define RTIMER_TIMER_ISR_DEV  E_AHI_DEVICE_SYSCTRL
+/* 1.5 days wraparound time */
+#define MAX_VALUE         0xFFFFFFFF
+/* make this small to more easily detect wraparound bugs */
+#define START_VALUE       (60 * RTIMER_ARCH_SECOND)
+#define WRAPAROUND_VALUE  ((uint64_t)0x1FFFFFFFFFF)
 
 static volatile rtimer_clock_t scheduled_time;
 static volatile uint8_t has_next;
 
-void
-rtimer_arch_run_next(uint32 u32DeviceId, uint32 u32ItemBitmap)
+/*---------------------------------------------------------------------------*/
+static void
+timerISR(uint32 u32Device, uint32 u32ItemBitmap)
 {
-  uint32_t delta;
-
-  if(u32DeviceId != RTIMER_TIMER_ISR_DEV) {
+  PRINTF("\ntimer isr %u %u\n", u32Device, u32ItemBitmap);
+  if(u32Device != RTIMER_TIMER_ISR_DEV) {
     return;
   }
 
   ENERGEST_ON(ENERGEST_TYPE_IRQ);
-  vAHI_TickTimerIntPendClr();
-  vAHI_TickTimerIntEnable(0);
-  /*
-   * compare register is only 28bits wide so make sure the upper 4bits match
-   * the set compare point
-   */
-  delta = u32AHI_TickTimerRead() - scheduled_time;
-  if(delta >> 28 == 0) {
-    /* run scheduled */
-    has_next = 0;
-    watchdog_start();
-    rtimer_run_next();
-    process_nevents();
-  } else {
-    /* No match. Schedule again. */
-    vAHI_TickTimerIntEnable(1);
-    vAHI_TickTimerInterval(scheduled_time);
+
+  if(u32ItemBitmap & TICK_TIMER_MASK) {
+    /* 32-bit overflow happened; restart the timer */
+    uint32_t ticks_late = WRAPAROUND_VALUE - u64AHI_WakeTimerReadLarge(TICK_TIMER);
+
+    PRINTF("\nrtimer oflw, missed ticks %u\n", ticks_late);
+    
+    vAHI_WakeTimerStartLarge(TICK_TIMER, MAX_VALUE - ticks_late);
   }
+
+  if(u32ItemBitmap & WAKEUP_TIMER_MASK) {
+    PRINTF("\nrtimer fire @ %u\n", rtimer_arch_now());
+
+    /* Compare with the current time, as after sleep there is
+     * a fake interrupt generated 10ms earlier to wake up & reinitialize
+     * the system before the actual rtimer fires.
+     */
+    rtimer_clock_t now = rtimer_arch_now();
+    if(RTIMER_CLOCK_LT(now + 1, scheduled_time)) {
+      vAHI_WakeTimerEnable(WAKEUP_TIMER, TRUE);
+      vAHI_WakeTimerStartLarge(WAKEUP_TIMER, scheduled_time - now);
+    } else {
+      has_next = 0;
+      watchdog_start();
+      rtimer_run_next();
+      process_nevents();
+    }
+  }
+
   ENERGEST_OFF(ENERGEST_TYPE_IRQ);
 }
 /*---------------------------------------------------------------------------*/
 void
 rtimer_arch_init(void)
 {
-  /* Initialise tick timer to run continuously */
-  vAHI_TickTimerConfigure(E_AHI_TICK_TIMER_DISABLE);
+  /* disable the tick timer */
   vAHI_TickTimerIntEnable(0);
-  vAHI_TickTimerRegisterCallback(rtimer_arch_run_next);
-  vAHI_TickTimerWrite(0);
-  vAHI_TickTimerConfigure(E_AHI_TICK_TIMER_CONT);
+  vAHI_TickTimerConfigure(E_AHI_TICK_TIMER_DISABLE);
 
-  /* enable wakeup timers, but keep interrupts disabled */
-  vAHI_WakeTimerEnable(WAKEUP_TIMER, FALSE);
-  vAHI_WakeTimerEnable(TICK_TIMER, FALSE);
-  /* count down from zero (2, as values 0 and 1 must not be used) */
-  vAHI_WakeTimerStartLarge(TICK_TIMER, 2);
+  vAHI_SysCtrlRegisterCallback(timerISR);
+  /* set the highest priority for the rtimer interrupt */
+  vAHI_InterruptSetPriority(MICRO_ISR_MASK_SYSCTRL, 15);
+  /* enable interrupt on a rtimer */
+  vAHI_WakeTimerEnable(WAKEUP_TIMER, TRUE);
+  /* enable interrupt on 32-bit overflow */
+  vAHI_WakeTimerEnable(TICK_TIMER, TRUE);
+  /* count down from START_VALUE */
+  vAHI_WakeTimerStartLarge(TICK_TIMER, START_VALUE);
 
   (void)u32AHI_Init();
 }
@@ -115,37 +131,30 @@ rtimer_arch_init(void)
 void
 rtimer_arch_reinit(rtimer_clock_t wakeup_time)
 {
-  /* Initialise tick timer to run continuously */
-  vAHI_TickTimerConfigure(E_AHI_TICK_TIMER_DISABLE);
-  vAHI_TickTimerIntEnable(0);
-  /* set the highest priority for the rtimer interrupt */
-  vAHI_InterruptSetPriority(MICRO_ISR_MASK_TICK_TMR, 15);
-  vAHI_TickTimerRegisterCallback(rtimer_arch_run_next);
-  vAHI_TickTimerWrite(wakeup_time);
-  vAHI_TickTimerConfigure(E_AHI_TICK_TIMER_CONT);
+  (void)wakeup_time;
+  /* call pending interrupts */
+  (void)u32AHI_Init();
 
-  if(has_next) {
-    vAHI_TickTimerIntPendClr();
-    vAHI_TickTimerIntEnable(1);
-    vAHI_TickTimerInterval(scheduled_time);
+  if (has_next) {
+    /* reschedule the timer */
+    rtimer_arch_schedule(scheduled_time);
   }
 }
 /*---------------------------------------------------------------------------*/
 rtimer_clock_t
 rtimer_arch_now(void)
 {
-  return u32AHI_TickTimerRead();
+  return START_VALUE - (rtimer_clock_t)u64AHI_WakeTimerReadLarge(TICK_TIMER);
 }
 /*---------------------------------------------------------------------------*/
 void
 rtimer_arch_schedule(rtimer_clock_t t)
 {
   PRINTF("rtimer_arch_schedule time %lu\n", t);
-  vAHI_TickTimerIntPendClr();
-  vAHI_TickTimerIntEnable(1);
-  vAHI_TickTimerInterval(t);
-  has_next = 1;
+  vAHI_WakeTimerEnable(WAKEUP_TIMER, TRUE);
+  vAHI_WakeTimerStartLarge(WAKEUP_TIMER, t - rtimer_arch_now());
   scheduled_time = t;
+  has_next = 1;
 }
 /*---------------------------------------------------------------------------*/
 rtimer_clock_t
@@ -159,4 +168,4 @@ rtimer_arch_get_time_until_next_wakeup(void)
   return (rtimer_clock_t)-1;
 }
 /*---------------------------------------------------------------------------*/
-#endif /* !RTIMER_USE_SLOW */
+#endif /* RTIMER_USE_SLOW */

--- a/platform/jn516x/dev/rtimer-arch-slow.c
+++ b/platform/jn516x/dev/rtimer-arch-slow.c
@@ -46,7 +46,7 @@
 #include "sys/energest.h"
 #include "sys/process.h"
 
-#if RTIMER_USE_SLOW
+#if RTIMER_USE_32KHZ
 
 #define DEBUG 0
 #if DEBUG
@@ -135,7 +135,7 @@ rtimer_arch_reinit(rtimer_clock_t wakeup_time)
   /* call pending interrupts */
   (void)u32AHI_Init();
 
-  if (has_next) {
+  if(has_next) {
     /* reschedule the timer */
     rtimer_arch_schedule(scheduled_time);
   }
@@ -168,4 +168,4 @@ rtimer_arch_get_time_until_next_wakeup(void)
   return (rtimer_clock_t)-1;
 }
 /*---------------------------------------------------------------------------*/
-#endif /* RTIMER_USE_SLOW */
+#endif /* RTIMER_USE_32KHZ */

--- a/platform/jn516x/dev/rtimer-arch.c
+++ b/platform/jn516x/dev/rtimer-arch.c
@@ -47,7 +47,7 @@
 #include "sys/energest.h"
 #include "sys/process.h"
 
-#if !RTIMER_USE_SLOW
+#if !RTIMER_USE_32KHZ
 
 #define DEBUG 0
 #if DEBUG
@@ -115,12 +115,14 @@ rtimer_arch_init(void)
 void
 rtimer_arch_reinit(rtimer_clock_t wakeup_time)
 {
+  uint64_t t;
   /* Initialise tick timer to run continuously */
   vAHI_TickTimerConfigure(E_AHI_TICK_TIMER_DISABLE);
   vAHI_TickTimerIntEnable(0);
   /* set the highest priority for the rtimer interrupt */
   vAHI_InterruptSetPriority(MICRO_ISR_MASK_TICK_TMR, 15);
   vAHI_TickTimerRegisterCallback(rtimer_arch_run_next);
+  WAIT_FOR_EDGE(t);
   vAHI_TickTimerWrite(wakeup_time);
   vAHI_TickTimerConfigure(E_AHI_TICK_TIMER_CONT);
 
@@ -159,4 +161,4 @@ rtimer_arch_get_time_until_next_wakeup(void)
   return (rtimer_clock_t)-1;
 }
 /*---------------------------------------------------------------------------*/
-#endif /* !RTIMER_USE_SLOW */
+#endif /* !RTIMER_USE_32KHZ */

--- a/platform/jn516x/dev/uart-driver.h
+++ b/platform/jn516x/dev/uart-driver.h
@@ -39,6 +39,8 @@
 #include <jendefs.h>
 #include "contiki-conf.h"
 
+#define UART_EXTRAS 1
+
 void uart_driver_init(uint8_t uart_dev, uint8_t br, uint8_t * txbuf_data, uint16_t txbuf_size, uint8_t * rxbuf_data, uint16_t rxbuf_size, int (*uart_input_function)(unsigned char c));
 void uart_driver_write_buffered(uint8_t uart_dev, uint8_t ch);
 void uart_driver_write_with_deadline(uint8_t uart_dev, uint8_t c);

--- a/platform/jn516x/platform-conf.h
+++ b/platform/jn516x/platform-conf.h
@@ -44,6 +44,8 @@
 /* Delay between GO signal and start listening
  * Measured 104us: between GO signal and start listening */
 #define RADIO_DELAY_BEFORE_RX ((unsigned)US_TO_RTIMERTICKS(104))
+/* Delay between the SFD finishes arriving and it is detected in software */
+#define RADIO_DELAY_BEFORE_DETECT ((unsigned)US_TO_RTIMERTICKS(14))
 
 /* Micromac configuration */
 
@@ -190,7 +192,9 @@ typedef uint32_t rtimer_clock_t;
 #define CLOCK_CONF_SECOND 100
 
 /* Shall we calibrate the DCO periodically? */
+#ifndef DCOSYNCH_CONF_ENABLED
 #define DCOSYNCH_CONF_ENABLED 1
+#endif
 
 /* How often shall we attempt to calibrate DCO?
  * PS: It should be calibrated upon temperature changes,

--- a/platform/jn516x/platform-conf.h
+++ b/platform/jn516x/platform-conf.h
@@ -61,9 +61,53 @@
 #define MICROMAC_CONF_CHANNEL RF_CHANNEL
 #endif
 
-/* Timer conversion
- * RTIMER 16M = 256 * 62500(RADIO)  == 2^8 * 62500 */
-#define RADIO_TO_RTIMER(X)                      ((rtimer_clock_t)((X) << (int32_t)8L))
+/* 32kHz or 16MHz rtimers? */
+#ifdef RTIMER_CONF_USE_32KHZ
+#define RTIMER_USE_32KHZ  RTIMER_CONF_USE_32KHZ
+#else
+#define RTIMER_USE_32KHZ  0
+#endif
+
+/* Put the device in a sleep mode in idle periods? */
+#ifdef JN516X_SLEEP_CONF_ENABLED
+#define JN516X_SLEEP_ENABLED JN516X_SLEEP_CONF_ENABLED
+#else
+#define JN516X_SLEEP_ENABLED 0
+#endif
+
+/* Enable this to get the 32.768kHz oscillator */
+#ifndef JN516X_EXTERNAL_CRYSTAL_OSCILLATOR
+#define JN516X_EXTERNAL_CRYSTAL_OSCILLATOR (RTIMER_USE_32KHZ || JN516X_SLEEP_ENABLED)
+#endif /* JN516X_EXTERNAL_CRYSTAL_OSCILLATOR */
+
+/* Core rtimer.h defaults to 16 bit timer unless RTIMER_CLOCK_LT is defined */
+typedef uint32_t rtimer_clock_t;
+#define RTIMER_CLOCK_LT(a, b)     ((int32_t)((a) - (b)) < 0)
+
+/* 10ms timer tick */
+#define CLOCK_CONF_SECOND 100
+
+#if JN516X_EXTERNAL_CRYSTAL_OSCILLATOR
+#define JN516X_XOSC_SECOND 32768
+#else
+#define JN516X_XOSC_SECOND 32000
+#endif
+
+/* Timer conversion*/
+#if RTIMER_USE_32KHZ
+#define RADIO_TO_RTIMER(X)  ((X) * (JN516X_XOSC_SECOND) / 62500)
+#else
+ /* RTIMER 16M = 256 * 62500(RADIO)  == 2^8 * 62500 */
+#define RADIO_TO_RTIMER(X)  ((rtimer_clock_t)((X) << (int32_t)8L))
+#endif
+
+/* If the timer base a binary 32kHz clock, compensate for this base drift */
+#if RTIMER_USE_32KHZ && JN516X_EXTERNAL_CRYSTAL_OSCILLATOR
+/* Drift calculated using this formula:
+*    ((US_TO_TICKS(10000) * 100) - RTIMER_SECOND) * 1e6 = 976.5625 ppm
+*/
+#define TSCH_CONF_BASE_DRIFT_PPM -977
+#endif
 
 #define DR_11744_DIO2 12
 #define DR_11744_DIO3 13
@@ -185,12 +229,6 @@ typedef long long int64_t;
 typedef uint16_t uip_stats_t;
 typedef uint32_t clock_time_t;
 
-/* Core rtimer.h defaults to 16 bit timer unless RTIMER_CLOCK_LT is defined */
-typedef uint32_t rtimer_clock_t;
-#define RTIMER_CLOCK_LT(a, b)     ((int32_t)((a) - (b)) < 0)
-/* 10ms timer tick */
-#define CLOCK_CONF_SECOND 100
-
 /* Shall we calibrate the DCO periodically? */
 #ifndef DCOSYNCH_CONF_ENABLED
 #define DCOSYNCH_CONF_ENABLED 1
@@ -226,11 +264,6 @@ typedef uint32_t rtimer_clock_t;
 #ifndef SLIP_BRIDGE_CONF_NO_PUTCHAR
 #define SLIP_BRIDGE_CONF_NO_PUTCHAR 1
 #endif /* SLIP_BRIDGE_CONF_NO_PUTCHAR */
-
-/* Enable this to get the 32.768kHz oscillator */
-#ifndef USE_EXTERNAL_OSCILLATOR
-#define USE_EXTERNAL_OSCILLATOR 0
-#endif /* USE_EXTERNAL_OSCILLATOR */
 
 /* Extension of LED definitions from leds.h for various JN516x dev boards 
 JN516x Dongle:

--- a/platform/sky/platform-conf.h
+++ b/platform/sky/platform-conf.h
@@ -52,6 +52,8 @@
 /* Delay between GO signal and start listening
  * ~50us delay + 129preample + ?? = 183 us */
 #define RADIO_DELAY_BEFORE_RX ((unsigned)US_TO_RTIMERTICKS(183))
+/* Delay between the SFD finishes arriving and it is detected in software */
+#define RADIO_DELAY_BEFORE_DETECT 0
 
 #define PLATFORM_HAS_LEDS    1
 #define PLATFORM_HAS_BUTTON  1

--- a/platform/z1/platform-conf.h
+++ b/platform/z1/platform-conf.h
@@ -49,6 +49,8 @@
 /* Delay between GO signal and start listening
  * ~50us delay + 129preample + ?? = 183 us */
 #define RADIO_DELAY_BEFORE_RX ((unsigned)US_TO_RTIMERTICKS(183))
+/* Delay between the SFD finishes arriving and it is detected in software */
+#define RADIO_DELAY_BEFORE_DETECT 0
 
 #define PLATFORM_HAS_LEDS    1
 #define PLATFORM_HAS_BUTTON  1


### PR DESCRIPTION
Implement adaptive time synchronization for TSCH as well as sleep mode and 32 kHz rtimers for JN516X platform. This patch also improves non-adaptive time sync for TSCH and accuracy of JN516X SFD timestamps.