### PR TITLE
Select JN5168 module using make target

### DIFF
--- a/apps/orchestra/orchestra-conf.h
+++ b/apps/orchestra/orchestra-conf.h
@@ -98,8 +98,8 @@
 /* Is the "hash" function collision-free? (e.g. it maps to unique node-ids) */
 #ifdef ORCHESTRA_CONF_COLLISION_FREE_HASH
 #define ORCHESTRA_COLLISION_FREE_HASH             ORCHESTRA_CONF_COLLISION_FREE_HASH
-#else /* ORCHESTRA_CONF_MAX_HASH */
-#define ORCHESTRA_CONF_COLLISION_FREE_HASH        0 /* Set to 1 if ORCHESTRA_LINKADDR_HASH returns unique hashes */
-#endif /* ORCHESTRA_CONF_MAX_HASH */
+#else /* ORCHESTRA_CONF_COLLISION_FREE_HASH */
+#define ORCHESTRA_COLLISION_FREE_HASH             0 /* Set to 1 if ORCHESTRA_LINKADDR_HASH returns unique hashes */
+#endif /* ORCHESTRA_CONF_COLLISION_FREE_HASH */
 
 #endif /* __ORCHESTRA_CONF_H__ */

--- a/platform/jn516x/Makefile.jn516x
+++ b/platform/jn516x/Makefile.jn516x
@@ -9,6 +9,11 @@ ifdef CHIP
 else
 JENNIC_CHIP ?= JN5168
 endif
+ifdef MODULE
+  JN5168_MODULE = $(MODULE)
+else
+  JN5168_MODULE ?= M00
+endif
 JENNIC_PCB ?= DEVKIT4
 JENNIC_STACK ?= MAC
 JENNIC_MAC ?= MiniMac
@@ -125,6 +130,10 @@ ifeq ($(JN516x_WITH_DONGLE),1)
 CFLAGS += -DDONGLE_NODE
 CONTIKI_TARGET_DIRS += dev/dongle
 ARCH += leds-arch.c
+endif
+
+ifeq ($(JENNIC_CHIP),JN5168)
+CFLAGS += -DJN5168_$(JN5168_MODULE)
 endif
 
 ifdef nodemac

--- a/platform/jn516x/README.md
+++ b/platform/jn516x/README.md
@@ -156,6 +156,15 @@ The following MCU models are supported:
 Set `CHIP` variable to change this; for example, to select JN5164 use:
 `make CHIP=JN5164`
 
+The JN5168 has four module variants available:
+* `M00` - Standard power, integrated antenna (default module)
+* `M03` - Standard power, uFL connector
+* `M05` - Medium power, uFL connector
+* `M06` - High power, uFL connector
+
+The `M05` and `M06` need to control the internal power amplifier. Set the `MODULE` variable to select the module, for example:
+`make CHIP=JN5168 MODULE=M05`
+
 The following platform-specific configurations are supported:
 * DR1174 evaluation kit; enable this with `JN516x_WITH_DR1174 = 1` in your makefile
 * DR1174 with DR1175 sensor board; enable this with `JN516x_WITH_DR1175 = 1` (will set `JN516x_WITH_DR1174` automatically)

--- a/platform/jn516x/platform-conf.h
+++ b/platform/jn516x/platform-conf.h
@@ -116,6 +116,13 @@ typedef uint32_t rtimer_clock_t;
 #define DR_11744_DIO6 16
 #define DR_11744_DIO7 17
 
+/* Enable power amplifier of JN5168 M05 and M06 modules */
+#if defined(JN5168_M05) || defined(JN5168_M06)
+#define RADIO_TEST_MODE RADIO_TEST_MODE_HIGH_PWR
+#else
+#define RADIO_TEST_MODE RADIO_TEST_MODE_DISABLED
+#endif
+
 #define TSCH_DEBUG 0
 
 #if TSCH_DEBUG


### PR DESCRIPTION
I added a make target to select the JN5168 module type. It enables the power amplifier for the M05 and M06 modules without the need to modify the code.
Usage:
`make TARGET=jn516x CHIP=JN5168 MODULE=M05`.

And I fixed the (remaining) configuration error in `orchestra-conf`.
